### PR TITLE
Add Briostack OTP and payment sample endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,12 @@ OPENAI_API_KEY="sk-123..."
 # (optional) Create an OpenAI Assistant at https://platform.openai.com/assistants.
 # IMPORTANT! Be sure to enable file search and code interpreter tools.
 OPENAI_ASSISTANT_ID="123..."
+# Briostack API credentials
+BRIOSTACK_INSTANCE_NAME="your-instance"
+BRIOSTACK_API_KEY="brio-key"
+
+# Twilio SMS credentials
+TWILIO_ACCOUNT_SID="sid"
+TWILIO_AUTH_TOKEN="token"
+TWILIO_FROM_NUMBER="+15555555555"
+

--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ The main logic for chat will be found in the `Chat` component in `app/components
 - `api/assistants/threads/[threadId]/actions` - `POST`: inform assistant of the result of a function it decided to call
 - `api/assistants/files` - `GET`/`POST`/`DELETE`: fetch, upload, and delete assistant files for file search
 
+### Briostack Integration Example
+
+The sample code also includes endpoints to verify customers via SMS and pull data from a Briostack instance.
+
+- `api/auth/send-code` - send a one time code to the customer's billing phone
+- `api/auth/verify-code` - verify the code before allowing access
+- `api/briostack/customer` - fetch a customer record once verified
+- `api/briostack/payment-link` - generate a simple payment link and send it via SMS
+
+Set the following environment variables to enable these endpoints:
+
+```
+BRIOSTACK_INSTANCE_NAME=<your-instance>
+BRIOSTACK_API_KEY=<api-key>
+TWILIO_ACCOUNT_SID=<sid>
+TWILIO_AUTH_TOKEN=<token>
+TWILIO_FROM_NUMBER=<from-number>
+```
 ## Feedback
 
 Let us know if you have any thoughts, questions, or feedback in [this form](https://docs.google.com/forms/d/e/1FAIpQLScn_RSBryMXCZjCyWV4_ebctksVvQYWkrq90iN21l1HLv3kPg/viewform?usp=sf_link)!

--- a/app/api/auth/send-code/route.ts
+++ b/app/api/auth/send-code/route.ts
@@ -1,0 +1,18 @@
+import { getCustomer } from "@/app/lib/briostack";
+import { generateOtp, saveOtp } from "@/app/lib/otp";
+import { sendSms } from "@/app/lib/notify";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  const { customerId } = await request.json();
+  const customer = await getCustomer(customerId);
+  const phone = customer?.billingMobile || customer?.billingPhone;
+  if (!phone) {
+    return new Response("Phone not found", { status: 400 });
+  }
+  const code = generateOtp();
+  saveOtp(customerId, code);
+  await sendSms(phone, `Your verification code is ${code}`);
+  return new Response(JSON.stringify({ sent: true }));
+}

--- a/app/api/auth/verify-code/route.ts
+++ b/app/api/auth/verify-code/route.ts
@@ -1,0 +1,9 @@
+import { verifyOtp } from "@/app/lib/otp";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  const { customerId, code } = await request.json();
+  const ok = verifyOtp(customerId, code);
+  return new Response(JSON.stringify({ valid: ok }), { status: ok ? 200 : 401 });
+}

--- a/app/api/briostack/customer/route.ts
+++ b/app/api/briostack/customer/route.ts
@@ -1,0 +1,13 @@
+import { getCustomer } from "@/app/lib/briostack";
+import { isVerified } from "@/app/lib/otp";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  const { customerId } = await request.json();
+  if (!isVerified(customerId)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  const customer = await getCustomer(customerId);
+  return new Response(JSON.stringify(customer));
+}

--- a/app/api/briostack/payment-link/route.ts
+++ b/app/api/briostack/payment-link/route.ts
@@ -1,0 +1,23 @@
+import { getCustomer } from "@/app/lib/briostack";
+import { isVerified } from "@/app/lib/otp";
+import { sendSms } from "@/app/lib/notify";
+
+export const runtime = "nodejs";
+
+function createPaymentLink(customerId: string, amount: number) {
+  return `https://pay.example.com/${customerId}?amount=${amount}`;
+}
+
+export async function POST(request: Request) {
+  const { customerId, amount } = await request.json();
+  if (!isVerified(customerId)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  const customer = await getCustomer(customerId);
+  const link = createPaymentLink(customerId, amount);
+  const phone = customer?.billingMobile || customer?.billingPhone;
+  if (phone) {
+    await sendSms(phone, `Pay here: ${link}`);
+  }
+  return new Response(JSON.stringify({ link }));
+}

--- a/app/lib/briostack.ts
+++ b/app/lib/briostack.ts
@@ -1,0 +1,25 @@
+export const instance = process.env.BRIOSTACK_INSTANCE_NAME;
+export const apiKey = process.env.BRIOSTACK_API_KEY;
+
+async function brioFetch(path: string, options: RequestInit = {}) {
+  if (!instance || !apiKey) {
+    throw new Error("Briostack credentials missing");
+  }
+  const url = `https://${instance}.briostack.io/rest/v1${path}`;
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      "x-api-key": apiKey,
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Briostack API error: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function getCustomer(customerId: string) {
+  return brioFetch(`/customers/${customerId}`);
+}

--- a/app/lib/notify.ts
+++ b/app/lib/notify.ts
@@ -1,0 +1,22 @@
+function toUrlEncoded(params: Record<string, string>) {
+  return new URLSearchParams(params).toString();
+}
+
+export async function sendSms(to: string, body: string) {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const from = process.env.TWILIO_FROM_NUMBER;
+  if (!accountSid || !authToken || !from) {
+    console.log(`SMS to ${to}: ${body}`);
+    return;
+  }
+  const credentials = Buffer.from(`${accountSid}:${authToken}`).toString("base64");
+  await fetch(`https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`, {
+    method: "POST",
+    headers: {
+      "Authorization": `Basic ${credentials}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: toUrlEncoded({ From: from, To: to, Body: body }),
+  });
+}

--- a/app/lib/otp.ts
+++ b/app/lib/otp.ts
@@ -1,0 +1,25 @@
+const store = new Map<string, { code: string; expires: number }>();
+
+export function generateOtp(): string {
+  return Math.floor(100000 + Math.random() * 900000).toString();
+}
+
+export function saveOtp(id: string, code: string, ttlSeconds = 300) {
+  store.set(id, { code, expires: Date.now() + ttlSeconds * 1000 });
+}
+
+export function verifyOtp(id: string, code: string): boolean {
+  const entry = store.get(id);
+  if (!entry) return false;
+  if (entry.expires < Date.now()) {
+    store.delete(id);
+    return false;
+  }
+  const ok = entry.code === code;
+  if (ok) store.delete(id);
+  return ok;
+}
+
+export function isVerified(id: string): boolean {
+  return !store.has(id);
+}


### PR DESCRIPTION
## Summary
- connect to Briostack with helper module
- send SMS OTP via Twilio helper
- verify OTP and fetch customer info
- generate payment link and text it to the customer
- document new endpoints in README
- provide env vars in `.env.example`

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*