### PR TITLE
Add Briostack function handler

### DIFF
--- a/.env
+++ b/.env
@@ -9,5 +9,5 @@ OPENAI_API_KEY="sk-123..."
 OPENAI_ASSISTANT_ID="123..."
 
 # Briostack API configuration
-BRIOSTACK_INSTANCE_NAME="your-instance"
-BRIOSTACK_API_KEY="your-api-key"
+BRIOSTACK_INSTANCE_NAME="demo-instance"
+BRIOSTACK_API_KEY="demo-api-key"

--- a/app/examples/all/page.tsx
+++ b/app/examples/all/page.tsx
@@ -5,17 +5,24 @@ import styles from "./page.module.css";
 import Chat from "../../components/chat";
 import WeatherWidget from "../../components/weather-widget";
 import { getWeather } from "../../utils/weather";
+import { handleBriostackCall } from "../../utils/briostack";
 import FileViewer from "../../components/file-viewer";
 
 const FunctionCalling = () => {
   const [weatherData, setWeatherData] = useState({});
 
   const functionCallHandler = async (call) => {
-    if (call?.function?.name !== "get_weather") return;
-    const args = JSON.parse(call.function.arguments);
-    const data = getWeather(args.location);
-    setWeatherData(data);
-    return JSON.stringify(data);
+    if (call?.function?.name === "get_weather") {
+      const args = JSON.parse(call.function.arguments);
+      const data = getWeather(args.location);
+      setWeatherData(data);
+      return JSON.stringify(data);
+    }
+    if (call?.function?.name === "call_briostack") {
+      const args = JSON.parse(call.function.arguments);
+      const result = await handleBriostackCall(args);
+      return JSON.stringify(result);
+    }
   };
 
   // return (

--- a/app/examples/basic-chat/page.tsx
+++ b/app/examples/basic-chat/page.tsx
@@ -3,12 +3,21 @@
 import React from "react";
 import styles from "./page.module.css"; // use simple styles for demonstration purposes
 import Chat from "../../components/chat";
+import { handleBriostackCall } from "../../utils/briostack";
 
 const Home = () => {
+  const functionCallHandler = async (call) => {
+    if (call?.function?.name === "call_briostack") {
+      const args = JSON.parse(call.function.arguments);
+      const result = await handleBriostackCall(args);
+      return JSON.stringify(result);
+    }
+  };
+
   return (
     <main className={styles.main}>
       <div className={styles.container}>
-        <Chat />
+        <Chat functionCallHandler={functionCallHandler} />
       </div>
     </main>
   );

--- a/app/examples/file-search/page.tsx
+++ b/app/examples/file-search/page.tsx
@@ -4,8 +4,17 @@ import styles from "../shared/page.module.css";
 
 import Chat from "../../components/chat";
 import FileViewer from "../../components/file-viewer";
+import { handleBriostackCall } from "../../utils/briostack";
 
 const FileSearchPage = () => {
+  const functionCallHandler = async (call) => {
+    if (call?.function?.name === "call_briostack") {
+      const args = JSON.parse(call.function.arguments);
+      const result = await handleBriostackCall(args);
+      return JSON.stringify(result);
+    }
+  };
+
   return (
     <main className={styles.main}>
       <div className={styles.container}>
@@ -14,7 +23,7 @@ const FileSearchPage = () => {
         </div>
         <div className={styles.chatContainer}>
           <div className={styles.chat}>
-            <Chat />
+            <Chat functionCallHandler={functionCallHandler} />
           </div>
         </div>
       </div>

--- a/app/examples/function-calling/page.tsx
+++ b/app/examples/function-calling/page.tsx
@@ -5,6 +5,7 @@ import styles from "../shared/page.module.css";
 import Chat from "../../components/chat";
 import WeatherWidget from "../../components/weather-widget";
 import { getWeather } from "../../utils/weather";
+import { handleBriostackCall } from "../../utils/briostack";
 import { RequiredActionFunctionToolCall } from "openai/resources/beta/threads/runs/runs";
 
 interface WeatherData {
@@ -18,11 +19,17 @@ const FunctionCalling = () => {
   const isEmpty = Object.keys(weatherData).length === 0;
 
   const functionCallHandler = async (call: RequiredActionFunctionToolCall) => {
-    if (call?.function?.name !== "get_weather") return;
-    const args = JSON.parse(call.function.arguments);
-    const data = getWeather(args.location);
-    setWeatherData(data);
-    return JSON.stringify(data);
+    if (call?.function?.name === "get_weather") {
+      const args = JSON.parse(call.function.arguments);
+      const data = getWeather(args.location);
+      setWeatherData(data);
+      return JSON.stringify(data);
+    }
+    if (call?.function?.name === "call_briostack") {
+      const args = JSON.parse(call.function.arguments);
+      const result = await handleBriostackCall(args);
+      return JSON.stringify(result);
+    }
   };
 
   return (

--- a/app/pest-landing/page.tsx
+++ b/app/pest-landing/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import Chat from "../components/chat";
+import { handleBriostackCall } from "../utils/briostack";
 import styles from "./page.module.css";
 
 const PestLanding = () => {
@@ -28,6 +29,14 @@ const PestLanding = () => {
   const scrollToContact = () => {
     const el = document.getElementById("contact");
     if (el) el.scrollIntoView({ behavior: "smooth" });
+  };
+
+  const functionCallHandler = async (call) => {
+    if (call?.function?.name === "call_briostack") {
+      const args = JSON.parse(call.function.arguments);
+      const result = await handleBriostackCall(args);
+      return JSON.stringify(result);
+    }
   };
 
   return (
@@ -185,7 +194,7 @@ const PestLanding = () => {
         <section id="chat">
           <h2>Chat with Our Assistant</h2>
           <p>Ask us anything about your account or services.</p>
-          <Chat />
+          <Chat functionCallHandler={functionCallHandler} />
         </section>
       </div>
 

--- a/app/utils/briostack.ts
+++ b/app/utils/briostack.ts
@@ -31,7 +31,7 @@ const brioFunction = {
 };
 
 // Call the Briostack API
-async function handleBriostackCall({
+export async function handleBriostackCall({
   endpoint,
   method,
   payload,


### PR DESCRIPTION
## Summary
- export `handleBriostackCall`
- add `functionCallHandler` with Briostack support to pages using `<Chat>`
- update example `.env` with demo Briostack credentials

## Testing
- `npm run lint` *(fails: `next` not found)*