### PR TITLE
Add ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next"
+}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ export OPENAI_API_KEY="sk_..."
 npm install
 ```
 
+Ensure this step completes while your environment still has network
+access so all required packages are downloaded.
+
 ### 4. Run
 
 ```shell

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "devDependencies": {
     "@types/node": "20.12.7",
     "@types/react": "18.2.79",
-    "typescript": "5.4.5"
+    "typescript": "5.4.5",
+    "eslint-config-next": "14.1.4"
   },
   "prettier": {
     "singleQuote": false


### PR DESCRIPTION
## Summary
- configure ESLint to use Next.js rules
- include eslint-config-next as a dev dependency
- note in README that installing packages requires network access

## Testing
- `npm run lint` *(fails: next not found)*