### PR TITLE
Add service schedule helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,21 @@ The `app/utils/briostack.ts` file also exposes helper methods like
 `listCustomers`, `getCustomer`, and `listProperties` for common API calls.
 Additional helpers such as `listAppointments`, `createAppointment`, and
 `listServices` demonstrate how to access other paid endpoints defined in the
-`public/briostack-openapi.json` specification. You can try them with the new
+`public/briostack-openapi.json` specification. Recent additions
+`listWebhooks`, `createWebhook`, `getWebhook`, and `updateWebhook` make it easy
+to manage webhook resources as well. New helpers `createService` and
+`updateService` let you modify a service's `serviceSchedule` if needed. You can
+try them with the new
 script:
 
 ```ts
 node scripts/briostack-appointments.ts
+```
+
+You can also inspect a service's schedule with:
+
+```ts
+node scripts/briostack-services.ts
 ```
 
 ## Feedback

--- a/app/utils/briostack.ts
+++ b/app/utils/briostack.ts
@@ -1,5 +1,29 @@
 import { openai } from "@/app/openai";
 
+// Types for service scheduling
+export interface AppointmentRegularSchedule {
+  useAppointmentPool?: boolean;
+  requiresConfirmation?: boolean;
+  scheduleType?: "NEVER" | "REGULAR" | "MONTHLY" | "CUSTOM";
+  regularScheduleInterval?: number;
+  regularScheduleIntervalType?: "DAYS" | "WEEKS" | "MONTHS";
+  monthlyScheduleMonths?: number[];
+  weeklyScheduleDays?: string[];
+  monthlyScheduleDays?: { dayOfTheWeek: string; weekNumber: number }[];
+}
+
+export interface ServiceSchedule {
+  customSequenceType?: "RANGE" | "SEQUENCE" | "NONE";
+  recurrence?: "ONETIME" | "RECURRING";
+  schedule?: AppointmentRegularSchedule;
+  onHold?: boolean;
+  lockAppointment?: boolean;
+  arrivalType?: "WINDOW" | "FIXED";
+  arriveAfter?: string;
+  arriveBefore?: string;
+  arriveAt?: string;
+}
+
 // Briostack function schema for OpenAI function calling
 const brioFunction = {
   name: "call_briostack",
@@ -164,3 +188,47 @@ export const getService = (
 
 export const listAllServices = (query?: Record<string, string>) =>
   handleBriostackCall({ endpoint: "/v1/services", method: "GET", query });
+
+export const createService = (
+  customerId: string,
+  payload: Record<string, unknown>
+) =>
+  handleBriostackCall({
+    endpoint: `/v1/customers/${customerId}/services`,
+    method: "POST",
+    payload,
+  });
+
+export const updateService = (
+  customerId: string,
+  serviceId: string,
+  payload: Record<string, unknown>
+) =>
+  handleBriostackCall({
+    endpoint: `/v1/customers/${customerId}/services/${serviceId}`,
+    method: "PATCH",
+    payload,
+  });
+
+// Webhook helpers
+export const listWebhooks = (query?: Record<string, string>) =>
+  handleBriostackCall({ endpoint: "/v1/webhooks", method: "GET", query });
+
+export const createWebhook = (payload: Record<string, unknown>) =>
+  handleBriostackCall({ endpoint: "/v1/webhooks", method: "POST", payload });
+
+export const getWebhook = (webhookId: string) =>
+  handleBriostackCall({
+    endpoint: `/v1/webhooks/${webhookId}`,
+    method: "GET",
+  });
+
+export const updateWebhook = (
+  webhookId: string,
+  payload: Record<string, unknown>
+) =>
+  handleBriostackCall({
+    endpoint: `/v1/webhooks/${webhookId}`,
+    method: "PUT",
+    payload,
+  });

--- a/scripts/briostack-services.ts
+++ b/scripts/briostack-services.ts
@@ -1,0 +1,11 @@
+import { getService } from "../app/utils/briostack";
+
+(async () => {
+  process.env.BRIOSTACK_INSTANCE_NAME = "pestproridall";
+  process.env.BRIOSTACK_API_KEY = "<YOUR_BRIOSTACK_API_KEY>";
+
+  const customerId = "<CUSTOMER_ID>";
+  const serviceId = "<SERVICE_ID>";
+  const service = await getService(customerId, serviceId);
+  console.log(service.serviceSchedule);
+})();


### PR DESCRIPTION
## Summary
- define `ServiceSchedule` and related types
- add `createService` and `updateService` helpers
- document new helpers and add script to inspect service schedules

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*