### PR TITLE
Rename env example and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # DO NOT COMMIT THIS FILE - IT WILL CONTAIN YOUR SENSITIVE KEYS.
-# Instead, rename this file to ".env" instead of ".env.example". (.env will not be committed)
+# Copy this file to ".env" and add your keys. (.env will not be committed)
 
 # Create an OpenAI API key at https://platform.openai.com/account/api-keys
 OPENAI_API_KEY="sk-123..."

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cd openai-assistants-quickstart
 export OPENAI_API_KEY="sk_..."
 ```
 
-(or in `.env.example` and rename it to `.env`).
+(or copy `.env.example` to `.env`).
 
 ### 3. Install dependencies
 


### PR DESCRIPTION
## Summary
- rename `.env` to `.env.example`
- update README to copy the new `.env.example`

## Testing
- `npm run lint` *(fails: next not found)*