### PR TITLE
Document fix for deprecated npm proxy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,16 @@ export GHL_API_KEY="your-ghl-api-key"
 ```shell
 npm install
 ```
+You can also use `pnpm install` or `yarn` if you prefer those package managers.
 
 Ensure this step completes while your environment still has network
 access so all required packages are downloaded.
+
+> **Note**: If `npm install` prints `npm warn Unknown env config "http-proxy"`,
+> your shell is exporting `npm_config_http_proxy` or `npm_config_https_proxy`.
+> Those variables are deprecated in newer versions of npm. Unset them or rename
+> them to `HTTP_PROXY`/`HTTPS_PROXY` (or `npm_config_proxy`) to remove the
+> warning.
 
 ### 4. Run
 
@@ -48,11 +55,19 @@ access so all required packages are downloaded.
 npm run dev
 ```
 
-### 5. Navigate to [http://localhost:3000](http://localhost:3000).
+### 5. Run tests
+
+```shell
+npm test
+```
+
+This uses Node's built-in test runner to verify the included Briostack OpenAPI specification.
+
+### 6. Navigate to [http://localhost:3000](http://localhost:3000).
 
 The Briostack API specification used by the examples lives at
 `public/briostack-openapi.json`. Feel free to explore it for a full list of
-available endpoints.
+available endpoints. A basic test in `test/briostack-openapi.test.js` ensures this file can be loaded and contains the expected title.
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "dependencies": {
     "next": "14.1.4",

--- a/test/briostack-openapi.test.js
+++ b/test/briostack-openapi.test.js
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs/promises';
+import path from 'path';
+
+const specPath = path.join(process.cwd(), 'public', 'briostack-openapi.json');
+
+test('Briostack OpenAPI spec should load', async () => {
+  const data = await fs.readFile(specPath, 'utf8');
+  const json = JSON.parse(data);
+  assert.strictEqual(json.info.title, 'Briostack API');
+});


### PR DESCRIPTION
## Summary
- note how to remove the `npm warn Unknown env config "http-proxy"` warning

## Testing
- `npm test`