### PR TITLE
Add Realtime API demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ You can also inspect a service's schedule with:
 node scripts/briostack-services.ts
 ```
 
+
+### Realtime API Demo
+
+This repo now includes a minimal example page using the new Realtime API.
+Run `npm run dev` and navigate to `/realtime` to try a WebRTC session in your
+browser. The `/api/realtime/session` endpoint mints an ephemeral token using
+your `OPENAI_API_KEY` for authentication. The client page then connects to the
+Realtime model and streams events back and forth.
+
 ### Messaging and Payments
 
 This template now includes optional API routes for sending SMS via Twilio,

--- a/app/api/realtime/session/route.ts
+++ b/app/api/realtime/session/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from "next/server";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest) {
+  const { model = "gpt-4o-realtime-preview-2024-12-17", voice = "nova" } = await req.json();
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return new Response("OpenAI API key not configured", { status: 500 });
+  }
+
+  const res = await fetch("https://api.openai.com/v1/realtime/sessions", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ model, voice }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    return new Response(text, { status: res.status });
+  }
+
+  const data = await res.json();
+  return Response.json(data);
+}

--- a/app/components/chat.module.css
+++ b/app/components/chat.module.css
@@ -1,7 +1,7 @@
 .chatContainer {
   display: flex;
-  flex-direction: column-reverse;
-  height: 100%;
+  flex-direction: column;
+  height: 100dvh;
   width: 100%;
 }
 
@@ -10,7 +10,7 @@
   width: 100%;
   padding: 10px;
   padding-bottom: 40px;
-  order: 1;
+  margin-top: auto;
 }
 
 .input {
@@ -48,7 +48,6 @@
   padding: 10px;
   display: flex;
   flex-direction: column;
-  order: 2;
   white-space: pre-wrap;
 }
 

--- a/app/examples/all/page.module.css
+++ b/app/examples/all/page.module.css
@@ -1,14 +1,15 @@
 .main {
   display: flex;
   justify-content: center;
-  align-items: center;
-  height: 100vh;
+  align-items: flex-start;
+  min-height: 100dvh;
+  padding: 20px 10px;
 }
 
 .container {
   display: flex;
   width: 100%;
-  height: 100vh;
+  min-height: 100dvh;
 }
 
 .column {
@@ -41,4 +42,14 @@
   max-width: 600px;
   width: 100%;
   height: 100%;
+}
+@media (max-width: 768px) {
+  .container {
+    flex-direction: column;
+  }
+  .column {
+    width: 100%;
+    height: auto;
+    margin: 10px 0;
+  }
 }

--- a/app/examples/basic-chat/page.module.css
+++ b/app/examples/basic-chat/page.module.css
@@ -1,8 +1,9 @@
 .main {
   display: flex;
   justify-content: center;
-  align-items: center;
-  height: 100vh;
+  align-items: flex-start;
+  min-height: 100dvh;
+  padding: 20px 10px;
   background-color: white;
 }
 
@@ -10,4 +11,13 @@
   max-width: 700px;
   width: 100%;
   height: 100%;
+}
+
+@media (max-width: 700px) {
+  .main {
+    padding: 10px;
+  }
+  .container {
+    height: calc(100dvh - 20px);
+  }
 }

--- a/app/examples/shared/page.module.css
+++ b/app/examples/shared/page.module.css
@@ -1,14 +1,15 @@
 .main {
   display: flex;
   justify-content: center;
-  align-items: center;
-  height: 100vh;
+  align-items: flex-start;
+  min-height: 100dvh;
+  padding: 20px 10px;
 }
 
 .container {
   display: flex;
   width: 100%;
-  height: 100vh;
+  min-height: 100dvh;
 }
 
 .column {
@@ -40,4 +41,14 @@
   max-width: 600px;
   width: 100%;
   height: 100%;
+}
+@media (max-width: 768px) {
+  .container {
+    flex-direction: column;
+  }
+  .column {
+    width: 100%;
+    height: auto;
+    margin: 10px 0;
+  }
 }

--- a/app/realtime/page.tsx
+++ b/app/realtime/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useState } from "react";
+
+export default function RealtimeDemo() {
+  const [log, setLog] = useState<string[]>([]);
+  const [pc, setPc] = useState<RTCPeerConnection | null>(null);
+
+  async function startWebRTC() {
+    const res = await fetch("/api/realtime/session", { method: "POST", body: JSON.stringify({})});
+    const data = await res.json();
+    const token = data.client_secret.value;
+
+    const connection = new RTCPeerConnection();
+    setPc(connection);
+
+    connection.ontrack = (e) => {
+      const audioEl = document.getElementById("remote-audio") as HTMLAudioElement;
+      audioEl.srcObject = e.streams[0];
+    };
+
+    const ms = await navigator.mediaDevices.getUserMedia({ audio: true });
+    connection.addTrack(ms.getTracks()[0]);
+
+    const dc = connection.createDataChannel("oai-events");
+    dc.addEventListener("message", (e) => {
+      setLog((prev) => [...prev, e.data]);
+    });
+
+    const offer = await connection.createOffer();
+    await connection.setLocalDescription(offer);
+
+    const res2 = await fetch(`https://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-12-17`, {
+      method: "POST",
+      body: offer.sdp,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/sdp",
+      },
+    });
+    const answer = { type: "answer", sdp: await res2.text() };
+    await connection.setRemoteDescription(answer);
+  }
+
+  return (
+    <main style={{ padding: "20px" }}>
+      <h1>Realtime API Demo</h1>
+      <p>This demo uses WebRTC to connect to the OpenAI Realtime API.</p>
+      <button onClick={startWebRTC}>Start Session</button>
+      <audio id="remote-audio" autoPlay />
+      <pre>{log.join("\n")}</pre>
+    </main>
+  );
+}

--- a/test/realtime-route.test.js
+++ b/test/realtime-route.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs/promises';
+import path from 'path';
+
+const routePath = path.join(process.cwd(), 'app', 'api', 'realtime', 'session', 'route.ts');
+
+test('Realtime session route exists', async () => {
+  try {
+    await fs.access(routePath);
+    assert.ok(true);
+  } catch (err) {
+    assert.fail('Realtime session route is missing');
+  }
+});


### PR DESCRIPTION
## Summary
- implement /api/realtime/session route for minting ephemeral tokens
- add simple WebRTC demo page at /realtime
- document how to try the realtime demo in README
- add test ensuring the realtime route exists
- improve chat layout responsiveness for mobile devices

## Testing
- `npm test`
